### PR TITLE
Package `bytelatent` as a module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,5 @@ setup(
     author="Meta Platforms, Inc. and affiliates.",
     url="https://github.com/facebookresearch/blt",
     packages=find_packages(),
-    install_requires=[
-        "sentencepiece",
-        "tiktoken",
-        "xformers"
-    ]
+    install_requires=["sentencepiece", "tiktoken", "xformers"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="bytelatent",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="bytelatent",
+    version="0.1.0",
+    description="Byte Latent Transformer: Patches Scale Better Than Tokens",
+    author="Meta Platforms, Inc. and affiliates.",
+    url="https://github.com/facebookresearch/blt",
+    packages=find_packages(),
+    install_requires=[
+        "numpy",
+        "omegaconf",
+        "msgspec",
+        "rouge-score",
+        "sacrebleu",
+        "sentencepiece",
+        "tiktoken",
+        "fsspec",
+        "blobfile",
+        "wandb",
+        "viztracer",
+        "lm-eval",
+        "scipy",
+        "pynvml",
+        "datatrove",
+        "orjson",
+        "luigi",
+        "pydantic",
+        "altair",
+        "submitit",
+        "typer",
+        "rich"
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "altair",
         "submitit",
         "typer",
-        "rich"
+        "rich",
+        "xformers"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,28 +8,8 @@ setup(
     url="https://github.com/facebookresearch/blt",
     packages=find_packages(),
     install_requires=[
-        "numpy",
-        "omegaconf",
-        "msgspec",
-        "rouge-score",
-        "sacrebleu",
         "sentencepiece",
         "tiktoken",
-        "fsspec",
-        "blobfile",
-        "wandb",
-        "viztracer",
-        "lm-eval",
-        "scipy",
-        "pynvml",
-        "datatrove",
-        "orjson",
-        "luigi",
-        "pydantic",
-        "altair",
-        "submitit",
-        "typer",
-        "rich",
         "xformers"
     ]
 )


### PR DESCRIPTION
This PR implements a `setup.py` file, such that BLT can be installed like a module, and integrated into other projects.

Pretty straightforward. You can see how I'm doing that [here](https://github.com/0-5788719150923125/praxis/blob/main/praxis/modules/encoder.py), if you like.