### PR TITLE
allow flex-attention to be disabled

### DIFF
--- a/bytelatent/base_transformer.py
+++ b/bytelatent/base_transformer.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-
+import os
 from enum import Enum
 from typing import Optional, Tuple, Union
 
@@ -16,9 +16,9 @@ from xformers.ops import AttentionBias, fmha
 
 from bytelatent import probe
 
-try:
+if int(os.environ.get("BLT_ALLOW_MISSING_FLEX_ATTENTION", False)) == 0:
     flex_attention_comp = torch.compile(flex_attention)
-except RuntimeError:
+else:
     flex_attention_comp = None
 
 

--- a/bytelatent/base_transformer.py
+++ b/bytelatent/base_transformer.py
@@ -16,7 +16,10 @@ from xformers.ops import AttentionBias, fmha
 
 from bytelatent import probe
 
-flex_attention_comp = torch.compile(flex_attention)
+try:
+    flex_attention_comp = torch.compile(flex_attention)
+except RuntimeError:
+    flex_attention_comp = None
 
 
 class InitStdFactor(Enum):

--- a/bytelatent/distributed.py
+++ b/bytelatent/distributed.py
@@ -48,8 +48,12 @@ default_no_recompute_ops = {
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.c10d_functional.reduce_scatter_tensor.default,
     torch.ops.xformers_flash.flash_fwd.default,
-    torch.ops.xformers.efficient_attention_forward_cutlass.default,
 }
+
+if "efficient_attention_forward_cutlass" in dir(torch.ops.xformers):
+    default_no_recompute_ops.add(
+        torch.ops.xformers.efficient_attention_forward_cutlass.default
+    )
 
 
 class DistributedArgs(BaseModel):

--- a/bytelatent/distributed.py
+++ b/bytelatent/distributed.py
@@ -1,5 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-
 import atexit
 import contextlib
 import logging
@@ -50,7 +49,7 @@ default_no_recompute_ops = {
     torch.ops.xformers_flash.flash_fwd.default,
 }
 
-if "efficient_attention_forward_cutlass" in dir(torch.ops.xformers):
+if int(os.environ.get("BLT_ALLOW_MISSING_FLEX_ATTENTION", False)) == 0:
     default_no_recompute_ops.add(
         torch.ops.xformers.efficient_attention_forward_cutlass.default
     )


### PR DESCRIPTION
Currently, I am dealing with two different failure states, when trying to import and use `bytelatent` as a module. The first is an incompatibility with Python 3.13:
```
RuntimeError: Dynamo is not supported on Python 3.13+
```
The second is that my GPU does not support FlexAttention, at all. And thus, `torch.compile(flex_attention)` will always fail - preventing me from using this lib.

This PR is a simple fix to both problems. If FlexAttention fails to compile, or if it is otherwise unavailable for any reason - this code will allow us to fallback to a simpler implementation.