### PR TITLE
Fix realtime entropy patching

### DIFF
--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -502,7 +502,6 @@ class Patcher:
         preds: torch.Tensor | None = None,
         entropies: torch.Tensor | None = None,
         threshold: float = None,
-        patching_batch_size: int | None = None,
     ) -> torch.Tensor:
         """
         tokens: 2D tensor of shape [batch_size, seq_len] that needs to be patched

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -2,6 +2,7 @@
 import math
 import time
 from collections import defaultdict
+from contextlib import nullcontext
 from enum import Enum
 
 import torch
@@ -63,7 +64,11 @@ def entropy(scores):
 
 
 def calculate_entropies(
-    tokens: torch.tensor, entropy_model, patching_batch_size, device: str | None = None
+    tokens: torch.tensor,
+    entropy_model,
+    patching_batch_size,
+    device: str | None = None,
+    enable_grad: bool = False,
 ):
     """
     tokens: 2D tensor of shape [batch_size, seq_len]
@@ -72,7 +77,10 @@ def calculate_entropies(
     Splits the tokens into chunks of size max_length and calculates entropies for each chunk.
     Entropy model can be executed on cpu or gpu, specify either 'cuda' or 'cpu' in the device argument.
     """
-    with torch.no_grad():
+
+    grad_context = nullcontext() if enable_grad else torch.no_grad()
+
+    with grad_context:
         entropies = []
         max_length = getattr(entropy_model, "max_length", 8192)
         batch_numel = max_length * patching_batch_size

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -490,6 +490,7 @@ class Patcher:
         preds: torch.Tensor | None = None,
         entropies: torch.Tensor | None = None,
         threshold: float = None,
+        patching_batch_size: int | None = None,
     ) -> torch.Tensor:
         """
         tokens: 2D tensor of shape [batch_size, seq_len] that needs to be patched
@@ -539,7 +540,11 @@ class Patcher:
                 scores = calculate_entropies(
                     tokens,
                     self.entropy_model,
-                    self.patching_batch_size,
+                    (
+                        patching_batch_size
+                        if patching_batch_size is not None
+                        else self.patching_batch_size
+                    ),
                     self.device,
                 )
             if self.log_time:

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 import torch
 from pydantic import BaseModel
-from torch import nn
 from torch.nn import functional as F
 
 from bytelatent.distributed import get_local_rank

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -26,12 +26,8 @@ class PatchingModeEnum(str, Enum):
 
 
 class PatcherArgs(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-
     patching_mode: PatchingModeEnum = PatchingModeEnum.entropy
     patching_device: str = "cuda"
-    entropy_model: nn.Module | None = None
     entropy_model_checkpoint_dir: str | None = None
     realtime_patching: bool = False
     threshold: float = 1.335442066192627
@@ -471,13 +467,13 @@ def split_large_numbers(lst, m):
 
 
 class Patcher:
-    def __init__(self, patcher_args: PatcherArgs):
+    def __init__(self, patcher_args: PatcherArgs, entropy_model: nn.Module = None):
         self.patcher_args = patcher_args
         self.patching_mode = patcher_args.patching_mode
         self.realtime_patching = patcher_args.realtime_patching
         if self.realtime_patching:
-            if patcher_args.entropy_model is not None:
-                self.entropy_model = patcher_args.entropy_model
+            if entropy_model is not None:
+                self.entropy_model = entropy_model
             else:
                 assert (
                     patcher_args.entropy_model_checkpoint_dir is not None

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -540,7 +540,7 @@ class Patcher:
             if self.log_time:
                 s = time.time()
             if entropies is not None:
-                scores = entropies.clone().detach().to(dtype=torch.float32)
+                scores = entropies.to(dtype=torch.float32)
             elif preds is not None:
                 scores = entropy(preds)
             else:

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -532,7 +532,7 @@ class Patcher:
             if self.log_time:
                 s = time.time()
             if entropies is not None:
-                scores = torch.tensor(entropies, dtype=torch.float32)
+                scores = entropies.clone().detach().to(dtype=torch.float32)
             elif preds is not None:
                 scores = entropy(preds)
             else:
@@ -540,11 +540,7 @@ class Patcher:
                 scores = calculate_entropies(
                     tokens,
                     self.entropy_model,
-                    (
-                        patching_batch_size
-                        if patching_batch_size is not None
-                        else self.patching_batch_size
-                    ),
+                    self.patching_batch_size,
                     self.device,
                 )
             if self.log_time:

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -467,24 +467,19 @@ def split_large_numbers(lst, m):
 
 
 class Patcher:
-    def __init__(self, patcher_args: PatcherArgs, entropy_model: nn.Module = None):
+    def __init__(self, patcher_args: PatcherArgs):
         self.patcher_args = patcher_args
         self.patching_mode = patcher_args.patching_mode
         self.realtime_patching = patcher_args.realtime_patching
         if self.realtime_patching:
-            if entropy_model is not None:
-                self.entropy_model = entropy_model
-            else:
-                assert (
-                    patcher_args.entropy_model_checkpoint_dir is not None
-                ), "Cannot require realtime patching without an entropy model checkpoint"
-                entropy_model = load_entropy_model(
-                    patcher_args.entropy_model_checkpoint_dir
-                )
-                entropy_model, _ = to_device(
-                    entropy_model, patcher_args.patching_device
-                )
-                self.entropy_model = entropy_model
+            assert (
+                patcher_args.entropy_model_checkpoint_dir is not None
+            ), "Cannot require realtime patching without an entropy model checkpoint"
+            entropy_model = load_entropy_model(
+                patcher_args.entropy_model_checkpoint_dir
+            )
+            entropy_model, _ = to_device(entropy_model, patcher_args.patching_device)
+            self.entropy_model = entropy_model
         else:
             self.entropy_model = None
         self.threshold = patcher_args.threshold

--- a/bytelatent/data/patcher.py
+++ b/bytelatent/data/patcher.py
@@ -118,6 +118,10 @@ def patch_start_mask_from_entropy_with_monotonicity(entropies, t):
     returns [bs, seq_len] mask where True indicates the start of a patch
     """
     bs, seq_len = entropies.shape
+
+    if seq_len == 0:
+        return entropies > t
+
     mask = torch.zeros_like(entropies, dtype=torch.bool)
     mask[:, 0] = True
 
@@ -140,6 +144,10 @@ def patch_start_mask_global_and_monotonicity(entropies, t, t_add=0):
     returns [bs, seq_len] mask where True indicates the start of a patch
     """
     bs, seq_len = entropies.shape
+
+    if seq_len == 0:
+        return entropies > t
+
     mask = torch.zeros_like(entropies, dtype=torch.bool)
     mask[:, 0] = True
 

--- a/bytelatent/model/local_models.py
+++ b/bytelatent/model/local_models.py
@@ -199,9 +199,6 @@ class LocalModelBase(nn.Module):
 class LocalEncoder(LocalModelBase):
     def __init__(self, args: LocalModelArgs):
         super().__init__(args)
-        self.output_proj = (
-            args.patching_mode in ["entropy", "probmax"]
-        ) and args.entropy_model_checkpoint_dir is None
 
         self.apply_transformer = args.use_local_encoder_transformer
         self.downsampling_by_pooling = args.downsampling_by_pooling

--- a/bytelatent/model/utils.py
+++ b/bytelatent/model/utils.py
@@ -162,9 +162,6 @@ def create_causal_mask(
             return "causal"
 
         if BLT_SUPPRESS_ATTN_ERROR == 1:
-            logging.warning(
-                "SDPA attention being used, which doesn't have specialized attention implementations for block_causal and local_block_causal attention. Allowing model to run since BLT_SUPPRESS_ATTN_ERROR=1"
-            )
             return "causal"
         else:
             raise ValueError(

--- a/bytelatent/preprocess/preprocess_entropies.py
+++ b/bytelatent/preprocess/preprocess_entropies.py
@@ -117,7 +117,7 @@ def main(
                         text = get_text(doc)
                         tokens = torch.tensor(tokenizer.encode(text))
                         patch_start = time.time()
-                        scores = calculate_entropies(
+                        scores, _ = calculate_entropies(
                             tokens,
                             entropy_model,
                             patching_batch_size,


### PR DESCRIPTION
This is a followup to the comment [made here](https://github.com/facebookresearch/blt/pull/25#issuecomment-2599152444).

I want to load and train an entropy model alongside of the latent model - rather than loading it from checkpoint. The current code does not support this, so I added an additional `PatcherArgs` attribute, called `entropy_model`. Here, you can pass a Pytorch module directly, instead of a checkpoint path.

I also removed a `self.output_proj` variable, because it crashes when using entropy patching. The `entropy_model_checkpoint_dir` attribute does not exist on `LocalModelArgs`. Regardless, this variable is unused - and probably not necessary?

Finally, I removed a logger warning that was extremely spammy. We are already gating this warning with the `BLT_SUPPRESS_ATTN_ERROR` environment variable, and I'm assuming you didn't intend on throwing the same warning with every forward pass. I'm sure this was overlooked, and you meant to remove this extra logging.

Let me know if you have any questions!