### PR TITLE
fix(README): correct typo in quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bash setup/create_env.sh
 sbatch setup/create_env.sh
 ```
 
-Once that is done your can activate the environment
+Once that is done you can activate the environment
 
 ```bash
 conda activate blt_<date>


### PR DESCRIPTION
Changed "your can activate the environment" to "you can activate the environment" for clarity.