### PR TITLE
Update iterator inheritance, pass file format args, limit iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ figures/
 internal/
 jobs_parallel-copy/
 wandb/
+*.ipynb
+

--- a/bytelatent/data/iterators/abstract_iterator.py
+++ b/bytelatent/data/iterators/abstract_iterator.py
@@ -2,6 +2,8 @@
 import abc
 from typing import Any, Generator, Generic, TypeVar
 
+import pydantic
+
 T = TypeVar("T")
 C = TypeVar("C")
 
@@ -21,6 +23,10 @@ class IteratorState(Generic[C]):
     @abc.abstractmethod
     def build(self) -> StatefulIterator[T, C]:
         pass
+
+
+class PydanticIteratorState(pydantic.BaseModel, IteratorState):
+    model_config = pydantic.ConfigDict(extra="forbid")
 
 
 def get_state_and_refresh(iterator: StatefulIterator):

--- a/bytelatent/data/iterators/dev_iterators.py
+++ b/bytelatent/data/iterators/dev_iterators.py
@@ -1,0 +1,78 @@
+import pandas as pd
+from pydantic import ConfigDict
+
+from bytelatent.data.data_types import BltExample
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
+
+
+class BltTestIteratorState(PydanticIteratorState):
+    model_config = ConfigDict(extra="forbid")
+    position: int
+    total: int
+
+    def build(self):
+        blt_iter = BltTestIteratorState(total=self.total)
+        blt_iter.position = self.position
+        return blt_iter
+
+
+class BltTestIterator(StatefulIterator):
+    def __init__(self, total: int):
+        self.position = 0
+        self.total = total
+
+    def get_state(self):
+        return BltTestIteratorState(position=self.position, total=self.total)
+
+    def create_iter(self):
+        for i in range(self.total):
+            self.position += 1
+            yield BltExample(
+                sample_id=f"test_{i}",
+                text=f"This is some test {i} text.",
+                tokens=None,
+                mask=None,
+                entropies=None,
+                patch_lengths=None,
+            )
+
+
+class BltTestWithEntropiesIteratorState(PydanticIteratorState):
+    model_config = ConfigDict(extra="forbid")
+    position: int
+    total: int
+
+    def build(self):
+        blt_iter = BltTestWithEntropiesIteratorState(total=self.total)
+        blt_iter.position = self.position
+        return blt_iter
+
+
+class BltTestWithEntropiesIterator(StatefulIterator):
+    def __init__(self, total: int):
+        self.position = 0
+        self.total = total
+
+    def get_state(self):
+        return BltTestIteratorState(position=self.position, total=self.total)
+
+    def create_iter(self):
+        text = "Daenerys Targaryen is in Game of Thrones, a fantasy epic by George R.R. Martin."
+        df = pd.read_json("fixtures/tokens_with_entropies.json")
+        tokens = df["token_ids"].tolist()
+        entropies = df["entropies"].tolist()
+        # BOS and EOS
+        assert len(tokens) == len(text) + 2
+        for i in range(self.total):
+            self.position += 1
+            yield BltExample(
+                sample_id=f"test_{i}",
+                text=text,
+                tokens=tokens,
+                mask=[True] * len(tokens),
+                entropies=entropies,
+                patch_lengths=None,
+            )

--- a/bytelatent/data/iterators/limit_iterator.py
+++ b/bytelatent/data/iterators/limit_iterator.py
@@ -1,0 +1,47 @@
+from pydantic import ConfigDict
+
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
+from bytelatent.data.iterators.arrow_iterator import ArrowFileIteratorState
+from bytelatent.data.iterators.dev_iterators import BltTestIteratorState
+
+
+class LimitIteratorState(PydanticIteratorState):
+    model_config = ConfigDict(extra="forbid")
+    base_iterator_state: (
+        BltTestIteratorState | ArrowFileIteratorState | PydanticIteratorState
+    )
+    n_yielded: int
+    limit: int
+
+    def build(self) -> "LimitIterator":
+        return LimitIterator(
+            base_iterator=self.base_iterator_state.build(),
+            n_yielded=self.n_yielded,
+            limit=self.limit,
+        )
+
+
+class LimitIterator(StatefulIterator):
+    def __init__(self, base_iterator: StatefulIterator, limit: int, n_yielded: int = 0):
+        self.base_iterator = base_iterator
+        self.n_yielded = n_yielded
+        self.limit = limit
+
+    def get_state(self):
+        return LimitIteratorState(
+            base_iterator_state=self.base_iterator.get_state(),
+            n_yielded=self.n_yielded,
+            limit=self.limit,
+        )
+
+    def create_iter(self):
+        iterator = self.base_iterator.create_iter()
+        try:
+            while self.n_yielded < self.limit or self.limit < 0:
+                yield next(iterator)
+                self.n_yielded += 1
+        except StopIteration:
+            pass

--- a/bytelatent/data/iterators/looping_iterator.py
+++ b/bytelatent/data/iterators/looping_iterator.py
@@ -1,14 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-from pydantic import BaseModel
 
-from bytelatent.data.iterators.abstract_iterator import IteratorState, StatefulIterator
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
 from bytelatent.data.iterators.arrow_iterator import (
     ArrowFileIterator,
     ArrowFileIteratorState,
 )
 
 
-class LoopingIteratorState(BaseModel, IteratorState):
+class LoopingIteratorState(PydanticIteratorState):
     file_iterator_state: ArrowFileIteratorState
     epoch: int
 

--- a/bytelatent/data/iterators/multiprocess_iterator.py
+++ b/bytelatent/data/iterators/multiprocess_iterator.py
@@ -6,16 +6,20 @@ from multiprocessing.synchronize import Event as EventClass
 from queue import Empty, Full
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 
 from bytelatent.data.data_types import Batch
-from bytelatent.data.iterators.abstract_iterator import IteratorState, StatefulIterator
+from bytelatent.data.iterators.abstract_iterator import (
+    IteratorState,
+    PydanticIteratorState,
+    StatefulIterator,
+)
 from bytelatent.data.iterators.packing_iterator import PackingIteratorState
 
 logger = logging.getLogger()
 
 
-class MultiprocessIteratorState(BaseModel, IteratorState):
+class MultiprocessIteratorState(PydanticIteratorState):
     model_config = ConfigDict(extra="forbid")
     base_iterator_state: PackingIteratorState
     n_batches_to_prefetch: int

--- a/bytelatent/data/iterators/packing_iterator.py
+++ b/bytelatent/data/iterators/packing_iterator.py
@@ -5,7 +5,10 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from bytelatent.data.data_types import Batch, BltSequence
-from bytelatent.data.iterators.abstract_iterator import IteratorState, StatefulIterator
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
 from bytelatent.data.iterators.sampling_iterator import SamplingIteratorState
 
 
@@ -20,7 +23,7 @@ class PackingArgs(BaseModel):
     tokenizer_name: str
 
 
-class PackingIteratorState(BaseModel, IteratorState):
+class PackingIteratorState(PydanticIteratorState):
     model_config = ConfigDict(extra="forbid")
     sequence_iterator_state: SamplingIteratorState
     packing_args: PackingArgs

--- a/bytelatent/data/iterators/preprocess_iterator.py
+++ b/bytelatent/data/iterators/preprocess_iterator.py
@@ -5,20 +5,29 @@ import torch
 from pydantic import BaseModel, ConfigDict
 
 from bytelatent.data.data_types import BltExample
-from bytelatent.data.iterators.abstract_iterator import IteratorState, StatefulIterator
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
 from bytelatent.data.iterators.arrow_iterator import (
     ArrowFileIterator,
     ArrowFileIteratorState,
 )
-from bytelatent.data.iterators.looping_iterator import LoopingIteratorState
+from bytelatent.data.iterators.limit_iterator import LimitIterator, LimitIteratorState
+from bytelatent.data.iterators.looping_iterator import (
+    LoopingIterator,
+    LoopingIteratorState,
+)
 from bytelatent.data.patcher import Patcher, PatcherArgs, PatchingModeEnum
 from bytelatent.tokenizers.blt_tokenizer import BltTokenizer
 from bytelatent.tokenizers.build_tokenizer import TokenizerArgs
 
 
-class PreprocessIteratorState(BaseModel, IteratorState):
+class PreprocessIteratorState(PydanticIteratorState):
     model_config = ConfigDict(extra="forbid")
-    arrow_file_iterator_state: ArrowFileIteratorState | LoopingIteratorState
+    arrow_file_iterator_state: (
+        ArrowFileIteratorState | LoopingIteratorState | LimitIteratorState
+    )
     add_tokens: bool
     add_patches: bool
     tokenizer_args: TokenizerArgs
@@ -43,7 +52,7 @@ class PreprocessIterator(StatefulIterator):
 
     def __init__(
         self,
-        arrow_iterator: ArrowFileIterator,
+        arrow_iterator: ArrowFileIterator | LoopingIterator | LimitIterator,
         *,
         patcher_args: PatcherArgs,
         tokenizer_args: TokenizerArgs,

--- a/bytelatent/data/iterators/sampling_iterator.py
+++ b/bytelatent/data/iterators/sampling_iterator.py
@@ -2,13 +2,16 @@
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 
-from bytelatent.data.iterators.abstract_iterator import StatefulIterator
+from bytelatent.data.iterators.abstract_iterator import (
+    PydanticIteratorState,
+    StatefulIterator,
+)
 from bytelatent.data.iterators.sequence_iterator import SequenceIteratorState
 
 
-class SamplingIteratorState(BaseModel):
+class SamplingIteratorState(PydanticIteratorState):
     model_config = ConfigDict(extra="forbid")
     rng_state: dict[str, Any]
     source_to_weight: dict[str, float]

--- a/bytelatent/data/iterators/test_arrow_iterator.py
+++ b/bytelatent/data/iterators/test_arrow_iterator.py
@@ -6,7 +6,10 @@ import pyarrow as pa
 import pyarrow.dataset  # pyright: ignore
 
 from bytelatent.constants import BLT_DATA
-from bytelatent.data.iterators.arrow_iterator import ArrowFileIteratorState
+from bytelatent.data.iterators.arrow_iterator import (
+    ArrowFileIterator,
+    ArrowFileIteratorState,
+)
 
 ENTROPY_MODEL = "transformer_100m"
 ARROW_TEST_DATA_1 = str(BLT_DATA / "stackexchange.chunk.00.jsonl.shard_00.arrow")
@@ -93,3 +96,19 @@ def test_basic_arrow_file():
         i += 1
         if i >= len(expected_ids):
             break
+
+
+def test_read_jsonl_from_arrow():
+    arrow_iterator = ArrowFileIterator(
+        file_path="fixtures/test_docs.jsonl",
+        num_workers=1,
+        worker_id=0,
+        preprocess_dir=None,
+        entropy_model_name=None,
+        file_format="json",
+        arrow_batch_size=100,
+    )
+    iterator = arrow_iterator.create_iter()
+    for i, example in enumerate(iterator):
+        assert example.sample_id == str(i)
+        assert example.text == f"test_{i}"

--- a/bytelatent/data/iterators/test_iters.py
+++ b/bytelatent/data/iterators/test_iters.py
@@ -1,81 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-import pandas as pd
-from pydantic import BaseModel
 
 from bytelatent.constants import BLT_DATA
-from bytelatent.data.data_types import BltExample
-from bytelatent.data.iterators.abstract_iterator import IteratorState, StatefulIterator
+from bytelatent.data.iterators.dev_iterators import (
+    BltTestIterator,
+    BltTestWithEntropiesIterator,
+)
 from bytelatent.data.iterators.preprocess_iterator import PreprocessIterator
 from bytelatent.data.patcher import PatcherArgs, PatchingModeEnum
 from bytelatent.tokenizers.build_tokenizer import TokenizerArgs
-
-
-class BltTestIteratorState(BaseModel, IteratorState):
-    position: int
-    total: int
-
-    def build(self):
-        blt_iter = BltTestIteratorState(total=self.total)
-        blt_iter.position = self.position
-        return blt_iter
-
-
-class BltTestIterator(StatefulIterator):
-    def __init__(self, total: int):
-        self.position = 0
-        self.total = total
-
-    def get_state(self):
-        return BltTestIteratorState(position=self.position, total=self.total)
-
-    def create_iter(self):
-        for i in range(self.total):
-            self.position += 1
-            yield BltExample(
-                sample_id=f"test_{i}",
-                text=f"This is some test {i} text.",
-                tokens=None,
-                mask=None,
-                entropies=None,
-                patch_lengths=None,
-            )
-
-
-class BltTestWithEntropiesIteratorState(BaseModel, IteratorState):
-    position: int
-    total: int
-
-    def build(self):
-        blt_iter = BltTestWithEntropiesIteratorState(total=self.total)
-        blt_iter.position = self.position
-        return blt_iter
-
-
-class BltTestWithEntropiesIterator(StatefulIterator):
-    def __init__(self, total: int):
-        self.position = 0
-        self.total = total
-
-    def get_state(self):
-        return BltTestIteratorState(position=self.position, total=self.total)
-
-    def create_iter(self):
-        text = "Daenerys Targaryen is in Game of Thrones, a fantasy epic by George R.R. Martin."
-        df = pd.read_json("fixtures/tokens_with_entropies.json")
-        tokens = df["token_ids"].tolist()
-        entropies = df["entropies"].tolist()
-        # BOS and EOS
-        assert len(tokens) == len(text) + 2
-        for i in range(self.total):
-            self.position += 1
-            yield BltExample(
-                sample_id=f"test_{i}",
-                text=text,
-                tokens=tokens,
-                mask=[True] * len(tokens),
-                entropies=entropies,
-                patch_lengths=None,
-            )
 
 
 def test_preprocess_iter():

--- a/bytelatent/data/iterators/test_limit_iterator.py
+++ b/bytelatent/data/iterators/test_limit_iterator.py
@@ -1,0 +1,45 @@
+from bytelatent.data.iterators.dev_iterators import BltTestIterator
+from bytelatent.data.iterators.limit_iterator import LimitIterator
+
+
+def test_limit_iterator():
+    total = 10
+    limit = 5
+    base_iterator = BltTestIterator(total=total)
+    limit_iterator = LimitIterator(base_iterator, limit=limit)
+    iterator = limit_iterator.create_iter()
+    n = 0
+    for example in iterator:
+        assert example.sample_id == f"test_{n}"
+        n += 1
+    assert n == limit
+
+    limit = 10
+    base_iterator = BltTestIterator(total=total)
+    limit_iterator = LimitIterator(base_iterator, limit=limit)
+    iterator = limit_iterator.create_iter()
+    n = 0
+    for example in iterator:
+        assert example.sample_id == f"test_{n}"
+        n += 1
+    assert n == limit == total
+
+    limit = 20
+    base_iterator = BltTestIterator(total=total)
+    limit_iterator = LimitIterator(base_iterator, limit=limit)
+    iterator = limit_iterator.create_iter()
+    n = 0
+    for example in iterator:
+        assert example.sample_id == f"test_{n}"
+        n += 1
+    assert n == total
+
+    limit = -1
+    base_iterator = BltTestIterator(total=total)
+    limit_iterator = LimitIterator(base_iterator, limit=limit)
+    iterator = limit_iterator.create_iter()
+    n = 0
+    for example in iterator:
+        assert example.sample_id == f"test_{n}"
+        n += 1
+    assert n == total

--- a/fixtures/test_docs.jsonl
+++ b/fixtures/test_docs.jsonl
@@ -1,0 +1,3 @@
+{"sample_id": "0", "text": "test_0"}
+{"sample_id": "1", "text": "test_1"}
+{"sample_id": "2", "text": "test_2"}


### PR DESCRIPTION

- Create a common class to use in all inheritance for states
- Add a limit iterator that we can use in evals
- Modify ArrowFileIterator behavior to not do arrow path inference if file_format='json'
- Make EvalArgs valid
- Move testing iterators to a common directory to allow usage in multiple test files
- Make it so that SequenceIterator can take a None rng_state, to disable all rng ops (for eval mainly)

Test Plan:

- `pytest bytelatent`
- `python -m bytelatent.train config=../internal-blt/configs/entropy_model.yaml logging.wandb=null eval=null`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/blt/pull/63).
* #65
* __->__ #63