### PR TITLE
Fix: Correct model_args usage in parallelize_model call

### DIFF
--- a/bytelatent/train.py
+++ b/bytelatent/train.py
@@ -317,7 +317,7 @@ def train(args: TrainArgs):
         model = parallelize_model(
             model,
             world_mesh,
-            args.model,
+            model_args,
             args.distributed,
             fsdp_grouping_plan=build_fsdp_grouping_plan(model_args),
             tp_parallelize=tp_parallelize,


### PR DESCRIPTION
Hi authors,

This PR updates the `parallelize_model` function to pass `model_args` instead of `args.model`. Previously, when training the entropy model, `args.model` was incorrectly passed, which (if I understood correctly) could result in `null` being used (e.g., in `bytelatent/configs/entropy_model.yaml`). 

Let me know if there’s anything else to adjust! 😊