### PR TITLE
Upgrade stool

### DIFF
--- a/bytelatent/templates/stool_template.sh.jinja
+++ b/bytelatent/templates/stool_template.sh.jinja
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+{{ exclude }}
+{{ qos }}
+{{ account }}
+{{ constraint }}
+#SBATCH --job-name={{ name }}
+#SBATCH --nodes={{ nodes }}
+#SBATCH --gres=gpu:{{ ngpus }}
+#SBATCH --cpus-per-gpu={{ ncpu }}
+#SBATCH --time={{ time }}
+#SBATCH --partition={{ partition }}
+#SBATCH --mem={{ mem }}
+
+#SBATCH --output={{ dump_dir }}/logs/%j/%j.stdout
+#SBATCH --error={{ dump_dir }}/logs/%j/%j.stderr
+
+#SBATCH --open-mode=append
+#SBATCH --signal=USR2@120
+#SBATCH --distribution=block
+
+{% if use_conda %}
+# Mimic the effect of "conda init", which doesn't work for scripts
+eval "$({{ conda_exe }} shell.bash hook)"
+source activate {{ conda_env_path }}
+{% endif %}
+
+{{ go_to_code_dir }}
+
+export OMP_NUM_THREADS=1
+export LAUNCH_WITH="SBATCH"
+export DUMP_DIR={{ dump_dir }}
+srun {{ log_output }} -n {{ tasks }} -N {{ nodes_per_run }} {{ python_command }} -u -m {{ script }} config=$DUMP_DIR/base_config.yaml dump_dir=$DUMP_DIR name={{ name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "datatrove>=0.5.0",
     "fsspec>=2024.6.1",
     "huggingface-hub==0.30.*",
+    "jinja2>=3.1.6",
     "lm-eval>=0.4.8",
     "luigi>=3.6.0",
     "numpy>=2.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -166,6 +166,7 @@ dependencies = [
     { name = "datatrove" },
     { name = "fsspec" },
     { name = "huggingface-hub" },
+    { name = "jinja2" },
     { name = "lm-eval" },
     { name = "luigi" },
     { name = "numpy" },
@@ -201,6 +202,7 @@ requires-dist = [
     { name = "datatrove", specifier = ">=0.5.0" },
     { name = "fsspec", specifier = ">=2024.6.1" },
     { name = "huggingface-hub", specifier = "==0.30.*" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "lm-eval", specifier = ">=0.4.8" },
     { name = "luigi", specifier = ">=3.6.0" },
     { name = "numpy", specifier = ">=2.1.2" },
@@ -2029,7 +2031,7 @@ wheels = [
 
 [[package]]
 name = "xformers"
-version = "0.0.29+de742ec.d20250502"
+version = "0.0.29+de742ec.d20250507"
 source = { git = "https://github.com/facebookresearch/xformers.git?rev=de742ec3d64bd83b1184cc043e541f15d270c148#de742ec3d64bd83b1184cc043e541f15d270c148" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION

Summary:

Modify stool so that:
- It uses jinja2 for better templating
- Add args to allow force non-interactive overrides
- Add config_parser argument to allow instantiation of pydantic class when some defaults don't exist and use it in stool, to allow the rest of the configuration parser to work.

Test Plan:

```
uv run python -m bytelatent.stool config=/storage/home/par/code/internal-blt/configs/par/stool/run_blt_1b_aws.yaml
uv run python -m bytelatent.train config=../internal-blt/configs/par/train/aws/blt_1b_dclm_aws.yaml dump_dir=/checkpoint/comem/par/scratch/debug data.batch_size=2
```
