### PR TITLE
Improve / patch UV installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ Run the following to install the env using [uv](https://docs.astral.sh/uv/).
 The main benefit of this method is that the build is reproducible since there is a lock file.
 
 ```bash
-uv pip install --group pre_build --no-build-isolation
-uv pip install --group compile_xformers --no-build-isolation
-uv sync
+uv sync --no-build-isolation-package pre_build --no-build-isolation-package compile_xformers
 uv run python download_blt_weights.py
 uv run python demo.py "A BLT has"
 ```


### PR DESCRIPTION
As I'm locally installing blt using `uv`, I noticed a minor inconvenience that I think could and should be improved.
The original installation steps are incomplete because uv run will fail if you have not run uv sync first.
```
uv pip install --group pre_build --no-build-isolation
uv pip install --group compile_xformers --no-build-isolation
uv sync
uv run python download_blt_weights.py
uv run python demo.py "A BLT has"
```
And uv sync will fail because the groups are not installed under the right flags.
I suggest using this oneliner that passes no isolation groups as arguments to uv sync instead,
making the installation experience smoother.
```
uv sync --no-build-isolation-package pre_build --no-build-isolation-package compile_xformers
uv run python download_blt_weights.py
uv run python demo.py "A BLT has"
```
Tested on uv `0.7.21`


Cheers